### PR TITLE
Enable motion vectors in the camera

### DIFF
--- a/Scripts/GroundTruthAmbientOcclusion.cs
+++ b/Scripts/GroundTruthAmbientOcclusion.cs
@@ -152,6 +152,7 @@ public class GroundTruthAmbientOcclusion : MonoBehaviour {
     void Awake()
     {
         RenderCamera = gameObject.GetComponent<Camera>();
+	RenderCamera.depthTextureMode = DepthTextureMode.Depth | DepthTextureMode.DepthNormals | DepthTextureMode.MotionVectors;
         GTAOMaterial = new Material(Shader.Find("Hidden/GroundTruthAmbientOcclusion"));
     }
 


### PR DESCRIPTION
Enable motion vectors in the camera. They aren't enabled by default, so unless you were using temporal anti alias using Unity's Post Processing stack, temporal filtering didn't work. This change enables the needed buffers in the camera.